### PR TITLE
💅 Attempt to install prettier packages, too

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ async function installEslintPackagesAsync () {
   const yarn = await getYarn()
 
   const versions = yarn.data.trees
-    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/))
+    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/) || p.name.match(/babel/))
     .map(p => p.name)
 
   await io.mv('package.json', 'package.json-bak')

--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ async function installEslintPackagesAsync () {
   const yarn = await getYarn()
 
   const versions = yarn.data.trees
-    .filter(p => p.name.match(/eslint/))
+    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/))
     .map(p => p.name)
 
   await io.mv('package.json', 'package.json-bak')

--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ async function installEslintPackagesAsync () {
   const yarn = await getYarn()
 
   const versions = yarn.data.trees
-    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/) || p.name.match(/babel/))
+    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/))
     .map(p => p.name)
 
   await io.mv('package.json', 'package.json-bak')


### PR DESCRIPTION
We're seeing some weird `prettier` annotations when linting a project that has `eslint` using some `prettier` configs. My theory is that different `prettier` versions are being installed depending on peer dependencies vs an explicit top-level dependency. 🤞

On the branch in question, this change did resolve the `prettier` warnings that were showing up in `balto-eslint`'s report, that do not show up in `development`. There are still 5 errors that are un-accounted for that show up in `balto-eslint`, but not in `development`. One step closer...