### PR TITLE
feat: Add issuesCount output value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# CHANGELOG
+
+## Unreleased
+
+- Add `issuesCount` output (https://github.com/planningcenter/balto-eslint/pull/7)
+
+## v0.3 (2019-12-03)
+
+- Install Prettier packages in addition to ESLint (https://github.com/planningcenter/balto-eslint/pull/4)
+
+## v0.2 (2019-11-08)
+
+- Update for ESLint v6 (https://github.com/planningcenter/balto-eslint/pull/2)
+
+## v0.1 (2019-10-17)
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ jobs:
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
 | `extensions` | A comma separated list of extensions to run ESLint on | no | `"js"` |
 
+## Outputs
+
+| Name | Description |
+|:-:|:-:|
+| `issuesCount` | Number of ESLint violations found |

--- a/action.yml
+++ b/action.yml
@@ -15,3 +15,6 @@ inputs:
     description: 'Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)'
     required: false
     default: "neutral"
+outputs:
+  issuesCount:
+    description: "Number of eslint violations found"

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const {
 } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
-const checkName = 'eslint'
+const checkName = 'ESLint'
 
 let yarnOutput = null
 

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const io = require('@actions/io')
-const { easyExec } = require('./utils')
+const { easyExec, setOutput } = require('./utils')
 const { generateChangeRanges } = require('./git_utils')
 const CheckRun = require('./check_run')
 
@@ -145,6 +145,7 @@ async function run () {
     }
   } finally {
     await checkRun.update(report)
+    setOutput("issuesCount", report.output.annotations.length)
   }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const exec = require('@actions/exec')
 
 exports.easyExec = async function easyExec (commandWithArgs) {
@@ -32,4 +33,8 @@ exports.easyExec = async function easyExec (commandWithArgs) {
     error,
     exitCode
   }
+}
+
+exports.setOutput = function setOutput (key, value) {
+  process.stdout.write(`::set-output name=${key}::${value}` + os.EOL)
 }


### PR DESCRIPTION
### Background
I'm using this action in another workflow that runs an auto-formatting action. I'd like to be able to skip the auto-formatting action if this ESLint action didn't find any issues in the changed files.

### Changes
While I only need a boolean output value, adding the number of issues/violations found seems potentially more useful while equally as easy to implement.