### PR TITLE
🆕 Switch to `eslint@7`'s new Node API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Find peer dependencies that begin with `@`
 - Fix: Include empty annotations array on error
+- Feature: Switch to `eslint@7`'s new Node API
 
 ## v0.4 (2021-04-08)
 


### PR DESCRIPTION
tired: `CLIEngine`
wired: `ESLint`

The API is a little different, and now asynchronous, and the output is a
little different. And also it requires >= `eslint@7`.

I also fixed a couple of bugs that I found along my journey.