### PR TITLE
👎 Allow specifying lowest failure level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5 (2022-03-06)
+
 - Feature: Allow specifying lowest failure level with `failureLevel`
 - Fix: Find peer dependencies that begin with `@`
 - Fix: Include empty annotations array on error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Feature: Allow specifying lowest failure level with `failureLevel`
 - Fix: Find peer dependencies that begin with `@`
 - Fix: Include empty annotations array on error
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ jobs:
 | Name | Description | Required | Default |
 |:-:|:-:|:-:|:-:|
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
+| `failureLevel` | The lowest annotation level to fail on | no | `"error"` |
 | `extensions` | A comma separated list of extensions to run ESLint on | no | `"js"` |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)'
     required: false
     default: "neutral"
+  failureLevel:
+    description: 'The lowest annotation level to fail on ("warning" or "error")'
+    required: false
+    default: "error"
 outputs:
   issuesCount:
     description: "Number of eslint violations found"

--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const CheckRun = require('./check_run')
 const {
   GITHUB_WORKSPACE,
   INPUT_EXTENSIONS,
-  INPUT_CONCLUSIONLEVEL
+  INPUT_CONCLUSIONLEVEL,
+  INPUT_FAILURELEVEL
 } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
@@ -120,8 +121,10 @@ async function runEslint () {
     }
   }
 
+  const totalCount = INPUT_FAILURELEVEL === "warning" ? errorCount + warningCount : errorCount
+
   return {
-    conclusion: errorCount > 0 ? INPUT_CONCLUSIONLEVEL : 'success',
+    conclusion: totalCount > 0 ? INPUT_CONCLUSIONLEVEL : 'success',
     output: {
       title: checkName,
       summary: `${errorCount} error(s), ${warningCount} warning(s) found`,


### PR DESCRIPTION
By default, checks pass as long as there are no errors.

This commit adds the ability to specify a `failureLevel` which, when set to "warning", will also fail if there are any warnings or errors.