### PR TITLE
🐞 Fix a couple of bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Find peer dependencies that begin with `@`
+- Fix: Include empty annotations array on error
 
 ## v0.4 (2021-04-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Find peer dependencies that begin with `@`
+
 ## v0.4 (2021-04-08)
 
 - Add `issuesCount` output (https://github.com/planningcenter/balto-eslint/pull/7)

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ async function getYarn () {
 async function getPeerDependencies (error) {
   const peers = error
     .split('\n')
-    .map(l => l.match(/ requires a peer of (?<packageName>[^@]+)@/))
+    .map(l => l.match(/ requires a peer of (?<packageName>.+)@/))
     .filter(m => m)
     .map(m => m.groups.packageName)
 

--- a/main.js
+++ b/main.js
@@ -141,7 +141,7 @@ async function run () {
   } catch (e) {
     report = {
       conclusion: 'failure',
-      output: { title: checkName, summary: `Balto error: ${e}` }
+      output: { title: checkName, summary: `Balto error: ${e}`, annotations: [] }
     }
   } finally {
     await checkRun.update(report)


### PR DESCRIPTION
- Find peer dependencies that begin with `@`
- Include empty annotations array on error