### PR TITLE
📦 Allow dependencies to be defined

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)'
     required: false
     default: "neutral"
+  dependencies:
+    description: 'An JSON-encoded array of dependencies (other than `eslint`) that `eslint` requires in order to complete the check'
+    required: false
+    default: '[]'
 outputs:
   issuesCount:
     description: "Number of eslint violations found"

--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const CheckRun = require('./check_run')
 const {
   GITHUB_WORKSPACE,
   INPUT_EXTENSIONS,
-  INPUT_CONCLUSIONLEVEL
+  INPUT_CONCLUSIONLEVEL,
+  INPUT_DEPENDENCIES
 } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
@@ -45,11 +46,15 @@ async function getPeerDependencies (error) {
   return versions
 }
 
+const BUILT_IN_DEPENDENCIES = ["eslint"]
+
 async function installEslintPackagesAsync () {
   const yarn = await getYarn()
 
+  const dependencies = [...BUILT_IN_DEPENDENCIES, ...JSON.parse(INPUT_DEPENDENCIES)]
+
   const versions = yarn.data.trees
-    .filter(p => p.name.match(/eslint/) || p.name.match(/prettier/))
+    .filter(p => dependencies.some(d => p.name.match(d)))
     .map(p => p.name)
 
   await io.mv('package.json', 'package.json-bak')


### PR DESCRIPTION
This commit allows a balto-eslint user to specify which packages they
need installed. The problem this solves is that, for example, if you use
`@babel/eslint-parser`, then that requires `@babel/core`. This is fine,
and it will get installed because it is a peer dependency. However, now
your babel config comes into play, and any plugins that are defined
there are required as well. However, those won't have been installed at
any point.

This commit also moves "prettier" into that status. In theory, there's
no reason we should assume the user wants that installed.