### PR TITLE
🆕  Feature: Add support for ESLint's new v7 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Feature: Support ESLint's new v7+ API (eslint.CLIEngine() has been removed as of v8)
+
 ## v0.5 (2022-03-06)
 
 - Feature: Allow specifying lowest failure level with `failureLevel`

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   extensions:
     description: "A comma separated list of extensions to run on"
-    require: false
+    required: false
     default: "js"
   conclusionLevel:
     description: 'Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)'

--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ async function installEslintPackagesAsync () {
   }
 }
 
-async function gatherReportForEslintSixOrLower (paths) {
+function gatherReportForEslintSixOrLower (paths) {
   const cli = new eslint.CLIEngine()
   return cli.executeOnFiles(paths)
 }
@@ -104,8 +104,8 @@ async function runEslint () {
 
   const eslintVersionSevenOrGreater = semver.gte(eslintVersion, '7.0.0')
 
-  const report = eslintVersionSevenOrGreater
-    ? gatherReportForEslintSevenOrGreater(paths)
+  const report = eslintVersionSevenOrGreater 
+    ? await gatherReportForEslintSevenOrGreater(paths)
     : gatherReportForEslintSixOrLower(paths)
 
   const { results, errorCount, warningCount } = report

--- a/main.js
+++ b/main.js
@@ -96,7 +96,8 @@ async function runEslint () {
   const { output } = await easyExec(
     `git diff --name-only --diff-filter AM ${compareSha}`
   )
-  const eslintVersion = require("./node_modules/eslint/package.json").version;
+  const eslintVersion = 
+    require(`${GITHUB_WORKSPACE}/node_modules/eslint/package.json`).version;
   const extensions = INPUT_EXTENSIONS.split(',')
 
   const paths = output

--- a/main.js
+++ b/main.js
@@ -83,8 +83,8 @@ async function gatherReportForEslintSevenOrGreater (paths) {
   return report.reduce(
     ({ results, errorCount, warningCount }, result) => ({
       results: [...results, result],
-      errorCount: (errorCount += result.errorCount),
-      warningCount: (warningCount += result.warningCount)
+      errorCount: errorCount + result.errorCount,
+      warningCount: warningCount + result.warningCount
     }),
     { results: [], errorCount: 0, warningCount: 0 }
   )

--- a/main.js
+++ b/main.js
@@ -11,8 +11,6 @@ const {
   INPUT_FAILURELEVEL
 } = process.env
 
-const eslint = require(`${GITHUB_WORKSPACE}/node_modules/eslint`)
-const eslintVersion = require('./node_modules/eslint/package.json').version
 const event = require(process.env.GITHUB_EVENT_PATH)
 const checkName = 'ESLint'
 
@@ -72,11 +70,13 @@ async function installEslintPackagesAsync () {
 }
 
 function gatherReportForEslintSixOrLower (paths) {
+  const eslint = require(`${GITHUB_WORKSPACE}/node_modules/eslint`);
   const cli = new eslint.CLIEngine()
   return cli.executeOnFiles(paths)
 }
 
 async function gatherReportForEslintSevenOrGreater (paths) {
+  const eslint = require(`${GITHUB_WORKSPACE}/node_modules/eslint`);
   const linter = new eslint.ESLint()
   const report = await linter.lintFiles(paths)
 
@@ -96,6 +96,7 @@ async function runEslint () {
   const { output } = await easyExec(
     `git diff --name-only --diff-filter AM ${compareSha}`
   )
+  const eslintVersion = require("./node_modules/eslint/package.json").version;
   const extensions = INPUT_EXTENSIONS.split(',')
 
   const paths = output


### PR DESCRIPTION
In v7 of ESLint `eslint.CLIEngine()` was deprecated, as of v8 is has been removed.

This allows folks who have yet to upgrade to continue using a version of ESLint < v8, but also provides support for those who have upgraded to the latest version using the new API.