### PR TITLE
chore: Readme updates, including permissions details

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # Optional but may be helpful depending on the ESLint plugins your project uses
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          # Change to package-lock.json if using npm in your own project
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - uses: planningcenter/balto-eslint@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions: # may not be necessary, see note below
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,3 +43,9 @@ jobs:
 | Name | Description |
 |:-:|:-:|
 | `issuesCount` | Number of ESLint violations found |
+
+## A note about permissions
+
+Because some tools, like [dependabot](https://github.com/dependabot), use tokens for actions that have read-only permissions, you'll need to elevate its permissions for this action to work with those sorts of tools. If you don't use any of those tools, and your workflow will only run when users with permissions in your repo create and update pull requests, you may not need these explicit permissions at all.
+
+When defining any permissions in a workflow or job, you need to explicitly include any permission the action needs. In the sample config above, we explicitly give `write` permissons to the [checks API](https://docs.github.com/en/rest/checks/runs) for the job that includes balto-eslint as a step. Because balto-eslint uses [check runs](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api), the `GITHUB_TOKEN` used in an action must have permissions to create a `check run`. You'll also need `contents: read` for `actions/checkout` to be able to clone the code.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Balto is Smart and Fast:
 
-* Installs _your_ version of eslint
 * Installs _your_ versions of eslint and eslint plugins
 * _Only_ runs on files that have changed
 * _Only_ annotates lines that have changed
@@ -17,20 +16,10 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          # Change to package-lock.json if using npm in your own project
-          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-          
       - uses: planningcenter/balto-eslint@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are two main things going on here. Each is represented by a separate commit.

1. General readme updating and clean up.
2. Add a note about getting this action to run with tools like dependabot.