### PR TITLE
Bugfix 🐛🔧: Remove relative path from `eslintVersion`

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ const {
 } = process.env
 
 const eslint = require(`${GITHUB_WORKSPACE}/node_modules/eslint`)
-const eslintVersion = require('./node_modules/eslint/package.json').version
+const eslintVersion = require(`${GITHUB_WORKSPACE}/node_modules/eslint/package.json`).version
 const event = require(process.env.GITHUB_EVENT_PATH)
 const checkName = 'ESLint'
 


### PR DESCRIPTION
Does what it says on the tin.

Somehow missed a relative path in the previous PR. This fixes that.