### PR TITLE
Quick implementation of dependencyInstallMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7 (2022-10-14)
+
 - Feature: configure dependency installation with `dependencyInstallMode` (https://github.com/planningcenter/balto-eslint/pull/20)
 - Internal only: Switch to NCC for building (https://github.com/planningcenter/balto-eslint/pull/18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Switch to NCC for building (should not affect consumers of this action) (https://github.com/planningcenter/balto-eslint/pull/18)
+- Feature: configure dependency installation with `dependencyInstallMode` (https://github.com/planningcenter/balto-eslint/pull/20)
+- Internal only: Switch to NCC for building (https://github.com/planningcenter/balto-eslint/pull/18)
 
 ## v0.6 (2022-09-14)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: planningcenter/balto-eslint@v0.6
+      - uses: planningcenter/balto-eslint@v0.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 Balto is Smart and Fast:
 
-* Installs _your_ versions of eslint and eslint plugins
+* Installs _your_ versions of eslint and eslint plugins (optionally)
 * _Only_ runs on files that have changed
 * _Only_ annotates lines that have changed
 
-Sample config (place in `.github/workflows/balto.yml`):
+## Requirements
+
+* Default configuration of `dependencyInstallMode` requires `yarn` to be used
+  * If you use npm you will need to set `dependencyInstallMode` to `'none'` and
+    handle the install yourself.
+
+## Sample config
+
+(place in `.github/workflows/balto.yml`):
 
 ```yaml
 name: Balto
@@ -47,6 +55,7 @@ jobs:
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
 | `failureLevel` | The lowest annotation level to fail on | no | `"error"` |
 | `extensions` | A comma separated list of extensions to run ESLint on | no | `"js"` |
+| `dependencyInstallMode` | `"smart"` or `"none"`. Control how dependencies are installed (if at all). Smart (requires yarn) will attempt to install the least amount of packages to successfully run eslint.| no | `"smart"` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,12 @@ inputs:
     description: 'The lowest annotation level to fail on ("warning" or "error")'
     required: false
     default: "error"
+  dependencyInstallMode:
+    description: "'smart'  or 'none'. Control how dependencies are installed (if
+      at all). Smart (requires yarn) will attempt to install the least amount of
+      packages to successfully run eslint."
+    required: false
+    default: 'smart'
 outputs:
   issuesCount:
     description: "Number of eslint violations found"

--- a/dist/index.js
+++ b/dist/index.js
@@ -14646,7 +14646,8 @@ const {
   GITHUB_WORKSPACE,
   INPUT_EXTENSIONS,
   INPUT_CONCLUSIONLEVEL,
-  INPUT_FAILURELEVEL
+  INPUT_FAILURELEVEL,
+  INPUT_DEPENDENCYINSTALLMODE
 } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
@@ -14808,7 +14809,7 @@ async function run () {
   let report = {}
   try {
     process.chdir(GITHUB_WORKSPACE)
-    await installEslintPackagesAsync()
+    if (INPUT_DEPENDENCYINSTALLMODE.toLowerCase() === "smart") await installEslintPackagesAsync()
     await setupEslintVersionAndLinter()
     report = await runEslint()
   } catch (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,8 @@ const {
   GITHUB_WORKSPACE,
   INPUT_EXTENSIONS,
   INPUT_CONCLUSIONLEVEL,
-  INPUT_FAILURELEVEL
+  INPUT_FAILURELEVEL,
+  INPUT_DEPENDENCYINSTALLMODE
 } = process.env
 
 const event = require(process.env.GITHUB_EVENT_PATH)
@@ -170,7 +171,7 @@ async function run () {
   let report = {}
   try {
     process.chdir(GITHUB_WORKSPACE)
-    await installEslintPackagesAsync()
+    if (INPUT_DEPENDENCYINSTALLMODE.toLowerCase() === "smart") await installEslintPackagesAsync()
     await setupEslintVersionAndLinter()
     report = await runEslint()
   } catch (e) {


### PR DESCRIPTION
## Why do we want this?

There are ways we'd like to use this action in the future that are limited by always attempting to install the minimal amount of packages.

Also, as Github actions has grown and changed, having this feature bundled in does not feel as beneficial as it did when we first created it.

## What changed?

With this PR, action consumers can configure `dependencyInstallMode` as either `"smart"` (default) or `"none"`. Smart will continue to function as expected and none will skip installation entirely.

## Why a string? Why not a boolean?

Great question! I prefer the string key as it makes expansion easier in the future. Originally, I had a `"full"` option as well, but in practice, that only saves a line or two on a workflow and increases the maintenance burden.