### PR TITLE
NCC: Explicitly allow all branches

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -1,6 +1,8 @@
 name: ncc
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
       - '**'
     paths:


### PR DESCRIPTION
I did not realize when we added `tags-ignore` that it would implicitly stop running for branches.

Adding the wildcard to explicitly allow all branches fixes this (I verified in a test branch).