### PR TITLE
Fix NCC workflow

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -1,23 +1,13 @@
 name: ncc
 on:
   push:
+    # Can't push a build commit to a tag, so only run for branches
     branches:
-      - '**'
-    tags-ignore:
       - '**'
     paths:
       - 'package-lock.json'
       - 'src/**'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: npm ci
-      - uses: planningcenter/balto-utils/ncc@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  ncc-build:
+    uses: planningcenter/balto-utils/.github/workflows/ncc.yml@v1


### PR DESCRIPTION
I broke this workflow when I added the tag filter (it stopped running for branch pushes). I fixed it later by adding the branch filter, but we can now remove the tag filter.

I also switched to the reusable workflow so that we are using a shared setup.

Confirmed to still be working after testing: 

- Action run https://github.com/planningcenter/balto-eslint/actions/runs/3413556956
- Build commit 291ea3081a0ca026220ce6bb909b1c130ac7127b

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203308302349068