### PR TITLE
chore(node): Update node version from `12` to `18`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Balto - Eslint"
 description: "Run eslint on your repo"
 runs:
-  using: node12
+  using: node18
   main: dist/index.js
 branding:
   icon: life-buoy

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Balto - Eslint"
 description: "Run eslint on your repo"
 runs:
-  using: node18
+  using: node16
   main: dist/index.js
 branding:
   icon: life-buoy


### PR DESCRIPTION
Now that all of our apps have moved on to Node v18, we should be able to update from the no-longer-supported v12, to the current v18.