### PR TITLE
chore: Setup automatic tag releases

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -1,0 +1,10 @@
+name: Release Tagger
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release-tagger:
+    uses: planningcenter/balto-utils/.github/workflows/release-tagger.yml@v1


### PR DESCRIPTION
Related: https://github.com/planningcenter/balto-rubocop/pull/34

(We'll want to have this setup before some forthcoming fixes)