### PR TITLE
docs: New version process updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+**Note:** changes since v0.7 can be found on the [releases page](https://github.com/planningcenter/balto-rubocop/releases)
 
 ## v0.7 (2022-10-14)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: planningcenter/balto-eslint@v0.7
+      - uses: planningcenter/balto-eslint@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Changelog
---

In other balto-* repos we are leaning into using Github releases to generate changelogs and have had good results with it. Cutting a new release becomes much easier and can be done almost entirely in the Github UI now. Because of this, we should make note of it in our CHANGELOG.

Readme
---

The semantic tag versioner that we added in #27 creates the following tags from `v0.8.0`

- `v0`
- `v0.8`

So let's update the Readme to point to the new major version tag: `v0`.

Normally, I wouldn't _feel_ great about having `v0` on the readme. But I am expecting that we will have a major version bump (`v1.0.0`) for this repo within the next few weeks as we bring over the check run -> workflow command changes we've already added to balto-rubocop.