### PR TITLE
chore: node16 -> node18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16
+nodejs 18

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Balto - Eslint"
 description: "Run eslint on your repo"
 runs:
-  using: node16
+  using: node18
   main: dist/index.js
 branding:
   icon: life-buoy


### PR DESCRIPTION
i'm getting a failure from this check in church-center ([link](https://github.com/planningcenter/church-center/actions/runs/7291379417/job/19870172485?pr=2121)):

```
Run yarn install --frozen-lockfile --prefer-offline --immutable
yarn install v1.22.21
[1/4] Resolving packages...
[2/4] Fetching packages...
error msw@2.0.11: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

 i think this is the most straightforward way to address that? looking here, looks like all the apps deploy with 18: https://github.com/search?q=org%3Aplanningcenter+%2FARG+NODE_VERSION%3D%2F&type=code&p=1 (possible that quick search is missing something non-dockerized).