### PR TITLE
chore: Update action to node20

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16
+nodejs 20

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Balto - Eslint"
 description: "Run eslint on your repo"
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: life-buoy


### PR DESCRIPTION
This spring, [actions will be running on node20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Actions not on node20 should be showing warnings now when ran. I've tested this with a separate repo and everything worked as expected.

I'm expecting this will be a minor version bump.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206274835341980