### PR TITLE
Allow dependabot to push ncc build commits to it's own branches

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'package-lock.json'
       - 'src/**'
+permissions:
+  # Allow dependabot to push updated builds to it's own branch
+  contents: write
 
 jobs:
   ncc-build:


### PR DESCRIPTION
The ncc workflow from balto-utils will build and attempt to push the build commit to the branch it was ran on. When dependabot opens a security update PR, it needs to re-run the build as well. The build runs just fine, but the default permissions for Github workflows prevent it from being able to push up the commit. Let's change that for just this workflow.

Because we have full control over the ncc action (it's our own typescript action, in our own utils repo), I'm less worried about issues here.

The alternative to doing this would be to manually build a push up a commit for each dependabot PR. That doesn't seem like a _huge_ lift as this is one of the first dependabot PRs since the v1 release, but as this is no ones full time focus, I'd like to optimize for ease of maintainability and make it easier to get security releases out faster.