### PR TITLE
feat: auto-detect package manager for ESLint invocation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26350,6 +26350,26 @@ const core = __importStar(__nccwpck_require__(2186));
 const git_utils_1 = __nccwpck_require__(5601);
 const exec_1 = __nccwpck_require__(1514);
 const eslint_result_1 = __nccwpck_require__(7023);
+const fs_1 = __nccwpck_require__(7147);
+function detectPackageManager(directory) {
+    if ((0, fs_1.existsSync)(`${directory}/.pnp.cjs`)) {
+        return "yarn-pnp";
+    }
+    if ((0, fs_1.existsSync)(`${directory}/pnpm-lock.yaml`)) {
+        return "pnpm";
+    }
+    return "npm";
+}
+function eslintCommand(packageManager) {
+    switch (packageManager) {
+        case "yarn-pnp":
+            return "yarn run eslint";
+        case "pnpm":
+            return "pnpm exec eslint";
+        default:
+            return "npx eslint";
+    }
+}
 async function run() {
     let workingDirectory = core.getInput("working-directory");
     if (workingDirectory) {
@@ -26379,7 +26399,9 @@ async function run() {
     // complain if the list is empty)
     if (changedFilesMatchingExtensions.length === 0)
         return;
-    let { stdout: eslintOut, exitCode } = await (0, exec_1.getExecOutput)("npx eslint --format=json", changedFilesMatchingExtensions, 
+    let packageManager = detectPackageManager(process.cwd());
+    core.debug(`Package manager: ${packageManager}`);
+    let { stdout: eslintOut, exitCode } = await (0, exec_1.getExecOutput)(`${eslintCommand(packageManager)} --format=json`, changedFilesMatchingExtensions, 
     // Eslint will return exit code 1 if it finds linting problems, but that is
     // expected and we don't want to stop execution because of it.
     { ignoreReturnCode: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,9 @@ import { getExecOutput } from "@actions/exec"
 import { ResultObject, ESLintResult } from "./eslint_result"
 import { existsSync } from "fs"
 
-function detectPackageManager(directory: string): "npm" | "yarn" | "pnpm" {
-  if (
-    existsSync(`${directory}/.pnp.cjs`) ||
-    existsSync(`${directory}/yarn.lock`)
-  ) {
-    return "yarn"
+function detectPackageManager(directory: string): "npm" | "yarn-pnp" | "pnpm" {
+  if (existsSync(`${directory}/.pnp.cjs`)) {
+    return "yarn-pnp"
   }
   if (existsSync(`${directory}/pnpm-lock.yaml`)) {
     return "pnpm"
@@ -17,9 +14,9 @@ function detectPackageManager(directory: string): "npm" | "yarn" | "pnpm" {
   return "npm"
 }
 
-function eslintCommand(packageManager: "npm" | "yarn" | "pnpm"): string {
+function eslintCommand(packageManager: "npm" | "yarn-pnp" | "pnpm"): string {
   switch (packageManager) {
-    case "yarn":
+    case "yarn-pnp":
       return "yarn run eslint"
     case "pnpm":
       return "pnpm exec eslint"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,31 @@ import * as core from "@actions/core"
 import { detectChangedFiles, detectChangedFilesInFolder } from "./git_utils"
 import { getExecOutput } from "@actions/exec"
 import { ResultObject, ESLintResult } from "./eslint_result"
+import { existsSync } from "fs"
+
+function detectPackageManager(directory: string): "npm" | "yarn" | "pnpm" {
+  if (
+    existsSync(`${directory}/.pnp.cjs`) ||
+    existsSync(`${directory}/yarn.lock`)
+  ) {
+    return "yarn"
+  }
+  if (existsSync(`${directory}/pnpm-lock.yaml`)) {
+    return "pnpm"
+  }
+  return "npm"
+}
+
+function eslintCommand(packageManager: "npm" | "yarn" | "pnpm"): string {
+  switch (packageManager) {
+    case "yarn":
+      return "yarn run eslint"
+    case "pnpm":
+      return "pnpm exec eslint"
+    default:
+      return "npx eslint"
+  }
+}
 
 async function run() {
   let workingDirectory = core.getInput("working-directory")
@@ -47,8 +72,11 @@ async function run() {
   // complain if the list is empty)
   if (changedFilesMatchingExtensions.length === 0) return
 
+  let packageManager = detectPackageManager(process.cwd())
+  core.debug(`Package manager: ${packageManager}`)
+
   let { stdout: eslintOut, exitCode } = await getExecOutput(
-    "npx eslint --format=json",
+    `${eslintCommand(packageManager)} --format=json`,
     changedFilesMatchingExtensions,
     // Eslint will return exit code 1 if it finds linting problems, but that is
     // expected and we don't want to stop execution because of it.


### PR DESCRIPTION
### Why?

We're investigating Yarn Plug'n'Play mode for more efficient git worktree installs. Yarn PnP stores packages in a virtual filesystem (zip archives) rather than `node_modules`, which `npx` can't resolve — causing ESLint to fail entirely in PnP environments.

### How?

Auto-detect the package manager from lock files and PnP artifacts (`.pnp.cjs`, `yarn.lock`, `pnpm-lock.yaml`) and invoke ESLint with the appropriate runner (`yarn run eslint`, `pnpm exec eslint`, or `npx eslint`) so the correct module resolution runtime is used.

### Testing

I tested this in https://github.com/planningcenter/publishing/actions/runs/23493015402/job/68366133454 and it works as expected.

<sub>Generated with Claude Code</sub>